### PR TITLE
Fixed Synchronous XMLHttpRequest on the main thread is deprecated

### DIFF
--- a/WebSDK/Api.js
+++ b/WebSDK/Api.js
@@ -463,7 +463,7 @@ CGoBoardApi.prototype.Embed = function (sDivId, oConfig)
     {
         sUrl        = decodeURIComponent(sUrl);
         var rawFile = new XMLHttpRequest();
-        rawFile["open"]("GET", sUrl + '?_=' + new Date().getTime(), false);
+        rawFile["open"]("GET", sUrl + '?_=' + new Date().getTime(), true);
 
         rawFile["onreadystatechange"] = function ()
         {


### PR DESCRIPTION
When using `sgfUrl` param happens warning: «Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check `https://xhr.spec.whatwg.org/`» 
Fix this.