### PR TITLE
Fix Reference Error of g_oTextMeasurer.

### DIFF
--- a/WebSDK/Drawing/Board.js
+++ b/WebSDK/Drawing/Board.js
@@ -3005,12 +3005,6 @@ CDrawingBoard.prototype.private_AddText = function(X, Y, event)
             var sLabelText = g_oLocalization ? g_oLocalization.gameRoom.labelPlaceholder : "Label...";
             var nLabelWidth = 50;
 
-            if (g_oTextMeasurer)
-			{
-				g_oTextMeasurer.SetFont("16px 'Times New Roman', Times, serif");
-				nLabelWidth = g_oTextMeasurer.Measure(sLabelText) + 6 + 2 + 2; // 6 padding 2 board 2 error
-			}
-
             var oAddLabelInput              = document.createElement("input");
             oAddLabelInput.style.position   = "absolute";
             oAddLabelInput.style.top        = oOffset.Y + oPos.Y - 10 + "px";

--- a/WebSDK/Drawing/Button.js
+++ b/WebSDK/Drawing/Button.js
@@ -1894,20 +1894,6 @@ function CDrawingButtonToolbarCustomize(oDrawing, oMutliLevelToolbar)
     this.m_nWidth  = 160;
     this.m_nHeight = 14 + 6 * 20;
 
-    if (g_oTextMeasurer)
-    {
-        g_oTextMeasurer.SetFont('16px "Times New Roman", Times, serif');
-
-        this.m_nWidth = 10 + 23 + Math.max(
-                g_oTextMeasurer.Measure(sMainNavigation),
-                g_oTextMeasurer.Measure(sTreeNavigation),
-                g_oTextMeasurer.Measure(sGeneralToolbar),
-                g_oTextMeasurer.Measure(sAutoplay),
-                g_oTextMeasurer.Measure(sTimeline),
-                g_oTextMeasurer.Measure(sKifuMode)
-            ) + 7;
-    }
-
     var oContextMenuElementWrapper              = document.createElement("div");
     oContextMenuElementWrapper.id               = oMainDiv.id + "ToolbarCustomizeWrapper";
     oContextMenuElementWrapper.style.position   = "absolute";

--- a/WebSDK/Drawing/Window.js
+++ b/WebSDK/Drawing/Window.js
@@ -806,34 +806,6 @@ CDrawingInfoWindow.prototype.Init = function(_sDivId, oPr)
 	var sTranscriber  = window.g_oLocalization ? window.g_oLocalization.gameRoom.window.gameInfo.transcriber : "Transcriber";
 	var sGameInfo     = window.g_oLocalization ? window.g_oLocalization.gameRoom.window.gameInfo.gameInfo : "Game info";
 
-	if (window.g_oTextMeasurer)
-	{
-		window.g_oTextMeasurer.SetFont("15px Tahoma, 'Sans serif'");
-
-		this.m_nLeftWidth = Math.max(
-			window.g_oTextMeasurer.Measure(sGameName),
-			window.g_oTextMeasurer.Measure(sResult),
-			window.g_oTextMeasurer.Measure(sRules),
-			window.g_oTextMeasurer.Measure(sKomi),
-			window.g_oTextMeasurer.Measure(sHandicap),
-			window.g_oTextMeasurer.Measure(sTimeSettings),
-			window.g_oTextMeasurer.Measure(sBlack),
-			window.g_oTextMeasurer.Measure(sBlackRank),
-			window.g_oTextMeasurer.Measure(sWhite),
-			window.g_oTextMeasurer.Measure(sWhiteRank),
-			window.g_oTextMeasurer.Measure(sCopyright),
-			window.g_oTextMeasurer.Measure(sDate),
-			window.g_oTextMeasurer.Measure(sEvent),
-			window.g_oTextMeasurer.Measure(sRound),
-			window.g_oTextMeasurer.Measure(sPlace),
-			window.g_oTextMeasurer.Measure(sAnnotator),
-			window.g_oTextMeasurer.Measure(sFuseki),
-			window.g_oTextMeasurer.Measure(sSource),
-			window.g_oTextMeasurer.Measure(sTranscriber),
-			window.g_oTextMeasurer.Measure(sGameInfo)
-		) + 12;
-	}
-
     this.protected_UpdateSizeAndPosition(oPr.Drawing);
 
     var oGameTree = oPr.GameTree;
@@ -1151,20 +1123,6 @@ CDrawingErrorWindow.prototype.Show = function(oPr)
     this.m_nW = oPr.W;
     this.m_nH = oPr.H;
     Common.Set_InnerTextToElement(this.m_oMainElement, oPr.ErrorText);
-
-    if (window.g_oTextMeasurer && this.m_nW - 14 > 0)
-	{
-		window.g_oTextMeasurer.SetFont("15px Tahoma, 'Sans serif'");
-		var nTextW = window.g_oTextMeasurer.Measure(oPr.ErrorText);
-
-		var nW = this.m_nW - 14;
-		var nH = (20 * Math.ceil((nTextW / nW) + 0.5)) + 10 + 30 + 7;
-
-		if (this.m_nH < nH)
-			this.m_nH = nH;
-
-		this.Update_Size(true);
-	}
 
     if (this.m_oDrawing)
     {
@@ -1556,17 +1514,6 @@ CDrawingCountColorsWindow.prototype.Init = function(_sDivId, oPr)
     var sBlue    = window.g_oLocalization ? window.g_oLocalization.gameRoom.window.colorsCounter.blue : "Blue";
 	var sGreen   = window.g_oLocalization ? window.g_oLocalization.gameRoom.window.colorsCounter.green : "Green";
 	var sGray    = window.g_oLocalization ? window.g_oLocalization.gameRoom.window.colorsCounter.gray : "Gray";
-
-	if (window.g_oTextMeasurer)
-	{
-		window.g_oTextMeasurer.SetFont("15px Tahoma, 'Sans serif'");
-		this.m_nLeftWidth = Math.max(
-			window.g_oTextMeasurer.Measure(sRed),
-			window.g_oTextMeasurer.Measure(sBlue),
-			window.g_oTextMeasurer.Measure(sGreen),
-			window.g_oTextMeasurer.Measure(sGray)
-		) + 12;
-	}
 
     this.m_oGameTree     = oPr.GameTree;
     this.m_oDrawingBoard = oPr.DrawingBoard;
@@ -2529,11 +2476,6 @@ CDrawingViewPortWindow.prototype.Init = function(_sDivId, oPr)
 
     var sReset = window.g_oLocalization ? window.g_oLocalization.gameRoom.window.boardCropping.buttonReset : "Reset";
     var nResetWidth = 100;
-    if (window.g_oTextMeasurer)
-    {
-        window.g_oTextMeasurer.SetFont("16px 'Segoe UI', Helvetica, Tahoma, Geneva, Verdana, sans-serif");
-        nResetWidth = window.g_oTextMeasurer.Measure(sReset) + 10;
-    }
 
     var sButtonResetId      = sMainId + "R";
     var oButtonResetElement = this.protected_CreateDivElement(oButtonsDiv, sButtonResetId);
@@ -3321,16 +3263,7 @@ CDrawingKifuWindow.prototype.private_DrawNextMove = function(oContext, nSize)
         var dOffsetX       = 20;
         oContext.fillText(sText, dOffsetX, dOffsetY);
 
-        var nLeft = 20;
-        if (window.g_oTextMeasurer)
-		{
-			window.g_oTextMeasurer.SetFont("16px Arial");
-			nLeft += window.g_oTextMeasurer.Measure(sText) + 5;
-		}
-		else
-		{
-			nLeft += 50;
-		}
+        var nLeft = 70;
 
         this.private_DrawStone(oContext, nValue, nLeft + nRad, 28 - nRad, nRad);
         this.private_DrawMoveNumber(oContext, nValue, nLeft + nRad, 28 - nRad, nRad, nNextMoveNumber);

--- a/WebSDK/Tests/BoardComNavToolbarTest.html
+++ b/WebSDK/Tests/BoardComNavToolbarTest.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>Board with comments, toolbar and navigator test</title>
+    
+    <script type="text/javascript" language="JavaScript" src="../Common.js"></script>
+
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Controls.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Board.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/BoardTarget.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/HtmlEvents.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Mark.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Button.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Toolbar.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Drawing.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/InterfaceState.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Comments.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Navigator.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/NavigatorMap.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Slider.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Sound.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Presentation.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/VerticalTabs.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Drawing/Window.js"></script>
+
+    <script type="text/javascript" language="JavaScript" src="../Command.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Consts.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../GameTree.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../GifWriter.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../LogicBoard.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Memory.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Move.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Node.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Territory.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../SgfReader.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../SgfWriter.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Api.js"></script>
+    <script type="text/javascript" language="JavaScript" src="../Version.js"></script>
+
+</head>
+<body style="position:absolute;padding:0;margin:0;">
+<div id="divId" style="position:relative; height: 100vh;width: 100vw" onfocus="BodyFocus()" tabindex="-1"></div>
+<script>
+    var oGameTree = GoBoardApi.Create_GameTree();
+    GoBoardApi.Create_BoardCommentsButtonsNavigator(oGameTree, "divId");
+    GoBoardApi.Load_Sgf(oGameTree, '(;FF[1]GM[1]SZ[19]GN[test];B[fj]CR[ii][ji][kh][pp][po][op];W[ip])');
+
+    window.onresize = function()
+    {
+        GoBoardApi.Update_Size(oGameTree);
+    };
+
+    function BodyFocus()
+    {
+        if (oGameTree)
+            GoBoardApi.Focus(oGameTree);
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
I made the test case: the web go board with comments, toolbar and navigator.
In this test case, each javascript is loaded in the html file like BoardTest.html instead of loading goboardmin.js.

I found this test failed in Firefox 54.0 on Ubuntu 16.04, to be more specific, the script aborted with the following error message:
    ReferenceError: g_oTextMeasurer is not defined.

It seems strange for me because the html works fine if we use goboardmin.js instead of each javascripts.
So I analyzed goboardmin.js and I found the variable g_oTextMeasurer is ommited in goboardmin.js.

Now, I ommit g_oTextMeasurer appeared in Drawing/Board.js, Drawing/Button.js and Drawing/Window.js, then the test case seems working fine.