### PR TITLE
Fix Issue "ST property is saved incorrectly"

### DIFF
--- a/WebSDK/Consts.js
+++ b/WebSDK/Consts.js
@@ -12,11 +12,12 @@ var BOARD_BLACK = 0x01;
 var BOARD_WHITE = 0x02;
 var BOARD_DRAW  = 0x03; // Это только для подсчета очков, для обозначения нейтральных пунктов.
 
+// EShowVariants value must be consistent with SGF ST property(0: children variation, 1: sibling variation, 2: "no (auto-) board markup).
 var EShowVariants =
 {
-    None : 0, // Не показвать варианты
+    Next : 0, // Все варианты следующего хода
     Curr : 1, // Альтернативные варианты текущего хода
-    Next : 2, // Все варианты следующего хода
+    None : 2, // Не показвать варианты
 
     Min  : 0,
     Max  : 2


### PR DESCRIPTION
fix #24 
As we mentioned in issue #24 , WebGoBoard may save incorrect ST property value.

The show mode is defined in Consts.js:
`var EShowVariants =`
`{`
`    None : 0, // Не показвать варианты`
`    Curr : 1, // Альтернативные варианты текущего хода`
`    Next : 2, // Все варианты следующего хода`
`    Min  : 0,`
`    Max  : 2`
`};`
and private_WriteGameInfo function writes the show mode value as ST property value in SGF file.
`    this.private_WriteCommand("ST", oGameTree.Get_ShowVariants());`

On the other hand, ST property value is defined as follows:
* show variations of successor node (children) (value: 0)
* show variations of current node   (siblings) (value: 1)
* no (auto-) board markup (value: 2)

So we saved the SGF file in the mode 'Next'(value: 2) on WebGoBoard, the ST property value would be '2'(no (auto-) board markup). That's why the incorrect ST property value is saved.

Our proposal is to modify the EShowVariants definition in order to be consistent with the ST property value definition. Specifically, the EShowVariants definition is modified as follows:
`var EShowVariants =`
`{`
`    Next : 0, // Все варианты следующего хода`
`    Curr : 1, // Альтернативные варианты текущего хода`
`    None : 2, // Не показвать варианты`
`    Min  : 0,`
`    Max  : 2`
`};`

